### PR TITLE
Fix length of magic massage

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -414,7 +414,7 @@ from ecdsa.util import string_to_number, number_to_string
 def msg_magic(message):
     varint = var_int(len(message))
     encoded_varint = "".join([chr(int(varint[i:i+2], 16)) for i in xrange(0, len(varint), 2)])
-    return "\x18Dogecoin Signed Message:\n" + encoded_varint + message
+    return "\x19Dogecoin Signed Message:\n" + encoded_varint + message
 
 
 def verify_message(address, signature, message):


### PR DESCRIPTION
Same bug as feathercoin (https://github.com/Feathercoin-Foundation/electrum-ftc/issues/106). The first character of the magic message is the length of the magic string, which apparently was copied from Bitcoin. But 'Dogecoin' has one more character than 'Bitcoin'.
Correspondingly, while electrum-doge works in itself, it would not be able to verify messages that were signed with dogecoin core or vice versa having dogecoin core verify messages that were signed with electrum-doge.
This fix changes electrum-doge to the dogecoin core conventions, which unfortunately breaks compatibility with previous (wrong) electrum-doge versions.

The string "Dogecoin Signed Message:\n" is 25 bytes like Litecoin, not 24 bytes like Bitcoin.